### PR TITLE
Add dedicated reading of distortion matrix

### DIFF
--- a/vega/build_config.py
+++ b/vega/build_config.py
@@ -207,6 +207,9 @@ class BuildConfig:
 
         # Write the basic info
         config['data']['filename'] = corr_info.get('corr_path')
+        if 'distortion-file' in corr_info:
+            config['data']['distortion-file'] = corr_info.get('distortion-file')
+
         config['cuts']['r-min'] = str(corr_info.get('r-min', 10))
         config['cuts']['r-max'] = str(corr_info.get('r-max', 180))
         config['cuts']['rt-min'] = str(corr_info.get('rt-min', 0))

--- a/vega/correlation_item.py
+++ b/vega/correlation_item.py
@@ -8,8 +8,10 @@ class CorrelationItem:
     _rp_rt_grid = None
     _r_mu_grid = None
     _z_grid = None
-    _bin_size_rp = None
-    _bin_size_rt = None
+    _bin_size_rp_model = None
+    _bin_size_rt_model = None
+    _bin_size_rp_data = None
+    _bin_size_rt_data = None
 
     def __init__(self, config, model_pk=False):
         """
@@ -121,17 +123,43 @@ class CorrelationItem:
             self._z_grid = z_grid
 
     @property
-    def bin_size_rp(self):
-        return self._bin_size_rp
+    def bin_size_rp_model(self):
+        if self._bin_size_rp_model is None:
+            raise ValueError('You must set the value of "bin_size_rp_model" in vega.corr_items to '
+                             'compute model without data.')
+        return self._bin_size_rp_model
 
-    @bin_size_rp.setter
-    def bin_size_rp(self, bin_size_rp):
-        self._bin_size_rp = bin_size_rp
+    @bin_size_rp_model.setter
+    def bin_size_rp_model(self, bin_size_rp_model):
+        self._bin_size_rp_model = bin_size_rp_model
 
     @property
-    def bin_size_rt(self):
-        return self._bin_size_rt
+    def bin_size_rt_model(self):
+        if self._bin_size_rt_model is None:
+            raise ValueError('You must set the value of "bin_size_rt_model" in vega.corr_items to '
+                             'compute model without data.')
+        return self._bin_size_rt_model
 
-    @bin_size_rt.setter
-    def bin_size_rt(self, bin_size_rt):
-        self._bin_size_rt = bin_size_rt
+    @bin_size_rt_model.setter
+    def bin_size_rt_model(self, bin_size_rt_model):
+        self._bin_size_rt_model = bin_size_rt_model
+
+    @property
+    def bin_size_rp_data(self):
+        if self._bin_size_rp_data is None:
+            return self.bin_size_rp_model
+        return self._bin_size_rp_data
+
+    @bin_size_rp_data.setter
+    def bin_size_rp_data(self, bin_size_rp_data):
+        self._bin_size_rp_data = bin_size_rp_data
+
+    @property
+    def bin_size_rt_data(self):
+        if self._bin_size_rt_data is None:
+            return self.bin_size_rt_model
+        return self._bin_size_rt_data
+
+    @bin_size_rt_data.setter
+    def bin_size_rt_data(self, bin_size_rt_data):
+        self._bin_size_rt_data = bin_size_rt_data

--- a/vega/data.py
+++ b/vega/data.py
@@ -31,7 +31,7 @@ class Data:
             Item object with the component config
         """
         # First save the tracer info
-        self._corr_item = corr_item
+        self.corr_item = corr_item
         self.tracer1 = corr_item.tracer1
         self.tracer2 = corr_item.tracer2
 
@@ -39,22 +39,22 @@ class Data:
         data_path = corr_item.config['data'].get('filename')
         dmat_path = corr_item.config['data'].get('distortion-file', None)
         rp_rt_grid, z_grid = self._read_data(data_path, corr_item.config['cuts'], dmat_path)
-        self._corr_item.rp_rt_grid = rp_rt_grid
-        self._corr_item.z_grid = z_grid
-        self._corr_item.bin_size_rp_model = self.bin_size_rp_model
-        self._corr_item.bin_size_rt_model = self.bin_size_rt_model
-        self._corr_item.bin_size_rp_data = self.bin_size_rp_data
-        self._corr_item.bin_size_rt_data = self.bin_size_rt_data
+        self.corr_item.rp_rt_grid = rp_rt_grid
+        self.corr_item.z_grid = z_grid
+        self.corr_item.bin_size_rp_model = self.bin_size_rp_model
+        self.corr_item.bin_size_rt_model = self.bin_size_rt_model
+        self.corr_item.bin_size_rp_data = self.bin_size_rp_data
+        self.corr_item.bin_size_rt_data = self.bin_size_rt_data
 
         # Read the metal file and init metals in the corr item
         if 'metals' in corr_item.config:
             tracer_catalog, metal_correlations = self._init_metals(
                                                  corr_item.config['metals'])
-            self._corr_item.init_metals(tracer_catalog, metal_correlations)
+            self.corr_item.init_metals(tracer_catalog, metal_correlations)
 
         # Check if we have broadband
         if 'broadband' in corr_item.config:
-            self._corr_item.init_broadband(self.coeff_binning_model)
+            self.corr_item.init_broadband(self.coeff_binning_model)
 
         if not self.has_distortion:
             self._distortion_mat = np.eye(self.full_data_size)
@@ -114,7 +114,7 @@ class Data:
         if self._cov_mat is None:
             raise AttributeError(
                 'No covariance matrix found. Check for it in the data file: ',
-                self._corr_item.config['data'].get('filename'))
+                self.corr_item.config['data'].get('filename'))
         return self._cov_mat
 
     @property
@@ -129,7 +129,7 @@ class Data:
         if self._distortion_mat is None:
             raise AttributeError(
                 'No distortion matrix found. Check for it in the data file: ',
-                self._corr_item.config['data'].get('filename'))
+                self.corr_item.config['data'].get('filename'))
         return self._distortion_mat
 
     @property
@@ -546,7 +546,7 @@ class Data:
             self.metal_mats[tracers] = csr_matrix(metal_hdul[2].data[dm_name])
         elif len(metal_hdul) > 3 and dm_name in metal_hdul[3].columns.names:
             self.metal_mats[tracers] = csr_matrix(metal_hdul[3].data[dm_name])
-        elif self._corr_item.test_flag:
+        elif self.corr_item.test_flag:
             self.metal_mats[tracers] = sparse.eye(metal_mat_size)
         else:
             raise ValueError("Cannot find correct metal matrices."

--- a/vega/data.py
+++ b/vega/data.py
@@ -37,12 +37,14 @@ class Data:
 
         # Read the data file and init the corrdinate grids
         data_path = corr_item.config['data'].get('filename')
-        rp_rt_grid, z_grid = self._read_data(data_path,
-                                             corr_item.config['cuts'])
+        dmat_path = corr_item.config['data'].get('distortion-file', None)
+        rp_rt_grid, z_grid = self._read_data(data_path, corr_item.config['cuts'], dmat_path)
         self._corr_item.rp_rt_grid = rp_rt_grid
         self._corr_item.z_grid = z_grid
-        self._corr_item.bin_size_rp = self.bin_size_rp
-        self._corr_item.bin_size_rt = self.bin_size_rt
+        self._corr_item.bin_size_rp_model = self.bin_size_rp_model
+        self._corr_item.bin_size_rt_model = self.bin_size_rt_model
+        self._corr_item.bin_size_rp_data = self.bin_size_rp_data
+        self._corr_item.bin_size_rt_data = self.bin_size_rt_data
 
         # Read the metal file and init metals in the corr item
         if 'metals' in corr_item.config:
@@ -96,8 +98,8 @@ class Data:
             Masked data vector (xi[mask])
         """
         if self._masked_data_vec is None:
-            self._masked_data_vec = np.zeros(self.mask.sum())
-            self._masked_data_vec[:] = self.data_vec[self.mask]
+            self._masked_data_vec = np.zeros(self.data_mask.sum())
+            self._masked_data_vec[:] = self.data_vec[self.data_mask]
         return self._masked_data_vec
 
     @property
@@ -141,8 +143,8 @@ class Data:
         """
         if self._inv_masked_cov is None:
             # Compute inverse of the covariance matrix
-            masked_cov = self.cov_mat[:, self.mask]
-            masked_cov = masked_cov[self.mask, :]
+            masked_cov = self.cov_mat[:, self.data_mask]
+            masked_cov = masked_cov[self.data_mask, :]
             try:
                 linalg.cholesky(self.cov_mat)
                 print('LOG: Full matrix is positive definite')
@@ -169,8 +171,8 @@ class Data:
         if self._log_cov_det is None:
             # Compute the log determinant using and LDL^T decomposition
             # |C| = Product of Diagonal components of D
-            masked_cov = self.cov_mat[:, self.mask]
-            masked_cov = masked_cov[self.mask, :]
+            masked_cov = self.cov_mat[:, self.data_mask]
+            masked_cov = masked_cov[self.data_mask, :]
             _, d, __ = linalg.ldl(masked_cov)
             self._log_cov_det = np.log(d.diagonal()).sum()
             assert isinstance(self.log_cov_det, float)
@@ -199,7 +201,7 @@ class Data:
         """
         return self._distortion_mat is not None
 
-    def _read_data(self, data_path, cuts_config):
+    def _read_data(self, data_path, cuts_config, dmat_path=None):
         """Read the data, mask it and prepare the environment.
 
         Parameters
@@ -209,24 +211,27 @@ class Data:
         cuts_config : ConfigParser
             cuts section from the config file
         """
-        print('Reading data file {}\n'.format(data_path))
+        print(f'Reading data file {data_path}\n')
         hdul = fits.open(find_file(data_path))
+        header = hdul[1].header
 
         self._blinding_strat = None
-        if 'BLINDING' in hdul[1].header:
-            self._blinding_strat = hdul[1].header['BLINDING']
+        if 'BLINDING' in header:
+            self._blinding_strat = header['BLINDING']
 
             if self._blinding_strat == 'none' or self._blinding_strat == 'None':
                 self._blinding_strat = None
 
+        dmat_column_name = 'DM'
         if self._blinding_strat in BLINDING_STRATEGIES:
-            print('Warning! Running on blinded data {}'.format(data_path))
+            print(f'Warning! Running on blinded data {data_path}')
             print(f'Strategy: {self._blinding_strat}. BAO can be sampled')
 
             self._blind = True
             self._data_vec = hdul[1].data['DA_BLIND']
-            if 'DM_BLIND' in hdul[1].columns.names:
-                self._distortion_mat = csr_matrix(hdul[1].data['DM_BLIND'])
+            dmat_column_name += '_BLIND'
+            if dmat_column_name in hdul[1].columns.names and dmat_path is None:
+                self._distortion_mat = csr_matrix(hdul[1].data[dmat_column_name])
 
         elif self._blinding_strat == 'desi_y3':
             raise ValueError('Fits are forbidden on Y3 data as we do not have'
@@ -235,8 +240,8 @@ class Data:
         elif self._blinding_strat is None:
             self._blind = False
             self._data_vec = hdul[1].data['DA']
-            if 'DM' in hdul[1].columns.names:
-                self._distortion_mat = csr_matrix(hdul[1].data['DM'])
+            if dmat_column_name in hdul[1].columns.names:
+                self._distortion_mat = csr_matrix(hdul[1].data[dmat_column_name])
 
         else:
             self._blind = True
@@ -248,39 +253,108 @@ class Data:
         rp_grid = hdul[1].data['RP']
         rt_grid = hdul[1].data['RT']
         z_grid = hdul[1].data['Z']
+
+        self.rp_min_data = header['RPMIN']
+        self.rp_max_data = header['RPMAX']
+        self.rt_max_data = header['RTMAX']
+        self.num_bins_rp_data = header['NP']
+        self.num_bins_rt_data = header['NT']
+
+        # Get the data bin size
+        # TODO If RTMIN is ever added to the cf data files this needs modifying
+        self.bin_size_rp_data = (self.rp_max_data - self.rp_min_data) / self.num_bins_rp_data
+        self.bin_size_rt_data = self.rt_max_data / self.num_bins_rt_data
+
         if 'NB' in hdul[1].columns.names:
             self.nb = hdul[1].data['NB']
         else:
             self.nb = None
 
-        try:
-            dist_rp_grid = hdul[2].data['DMRP']
-            dist_rt_grid = hdul[2].data['DMRT']
-            dist_z_grid = hdul[2].data['DMZ']
-        except (IndexError, KeyError):
-            dist_rp_grid = rp_grid.copy()
-            dist_rt_grid = rt_grid.copy()
-            dist_z_grid = z_grid.copy()
-        self.coeff_binning_model = np.sqrt(dist_rp_grid.size / rp_grid.size)
+        if len(hdul) > 2:
+            rp_grid_model = hdul[2].data['DMRP']
+            rt_grid_model = hdul[2].data['DMRT']
+            z_grid_model = hdul[2].data['DMZ']
+        else:
+            rp_grid_model = rp_grid
+            rt_grid_model = rt_grid
+            z_grid_model = z_grid
+        hdul.close()
 
-        # Compute the mask and use it on the data
-        self._build_mask(rp_grid, rt_grid, cuts_config, hdul[1].header)
+        # Compute the data mask
+        self.data_mask = self._build_mask(rp_grid, rt_grid, cuts_config, self.rp_min_data,
+                                          self.bin_size_rp_data, self.bin_size_rt_data)
+
+        # Read distortion matrix and initialize coordinate grids for the model
+        if dmat_path is not None:
+            rp_grid_model, rt_grid_model, z_grid_model = self._read_dmat(dmat_path, cuts_config,
+                                                                         dmat_column_name)
+        else:
+            self.rp_min_model = self.rp_min_data
+            self.rp_max_model = self.rp_max_data
+            self.rt_max_model = self.rt_max_data
+            self.num_bins_rp_model = self.num_bins_rp_data
+            self.num_bins_rt_model = self.num_bins_rt_data
+            self.bin_size_rp_model = self.bin_size_rp_data
+            self.bin_size_rt_model = self.bin_size_rt_data
+            self.coeff_binning_model = 1
+            self.model_mask = self.data_mask
 
         self.data_size = len(self.masked_data_vec)
         self.full_data_size = len(self.data_vec)
 
+        # TODO this was needed for post distortion BB polynomials. Fix at some point!
+        # self.r_square_grid = np.sqrt(rp_grid**2 + rt_grid**2)
+        # self.mu_square_grid = np.zeros(self.r_square_grid.size)
+        # w = self.r_square_grid > 0.
+        # self.mu_square_grid[w] = rp_grid[w] / self.r_square_grid[w]
+
+        # return the model coordinate grids
+        rp_rt_grid = np.array([rp_grid_model, rt_grid_model])
+        return rp_rt_grid, z_grid_model
+
+    def _check_if_blinding_matches(self, blinding_flag, dmat_path):
+        if self._blinding_strat is None:
+            if not (blinding_flag == 'none' or blinding_flag == 'None'):
+                raise ValueError(f'Data has no blinding, but distortion matrix at {dmat_path} '
+                                 f'has a blinding flag {blinding_flag}')
+        else:
+            if self._blinding_strat != blinding_flag:
+                raise ValueError(f'Data has a blinding flag {blinding_flag} that does not match '
+                                 f'the flag of the distortion matrix at {dmat_path}')
+
+    def _read_dmat(self, dmat_path, cuts_config, dmat_column_name):
+        print(f'Reading distortion matrix file {dmat_path}\n')
+        hdul = fits.open(find_file(dmat_path))
+        header = hdul[1].header
+
+        if 'BLINDING' in header:
+            self._check_if_blinding_matches(header['BLINDING'], dmat_path)
+
+        self._distortion_mat = csr_matrix(hdul[1].data[dmat_column_name])
+
+        rp_grid = hdul[2].data['RP']
+        rt_grid = hdul[2].data['RT']
+        z_grid = hdul[2].data['Z']
         hdul.close()
 
-        self.r_square_grid = np.sqrt(rp_grid**2 + rt_grid**2)
-        self.mu_square_grid = np.zeros(self.r_square_grid.size)
-        w = self.r_square_grid > 0.
-        self.mu_square_grid[w] = rp_grid[w] / self.r_square_grid[w]
+        self.rp_min_model = header['RPMIN']
+        self.rp_max_model = header['RPMAX']
+        self.rt_max_model = header['RTMAX']
+        self.num_bins_rp_model = header['NP']
+        self.num_bins_rt_model = header['NT']
+        self.coeff_binning_model = header['COEFMOD']
 
-        # return the coordinate grids
-        rp_rt_grid = np.array([dist_rp_grid, dist_rt_grid])
-        return rp_rt_grid, dist_z_grid
+        # Get the model bin size
+        # TODO If RTMIN is ever added to the cf data files this needs modifying
+        self.bin_size_rp_model = (self.rp_max_model - self.rp_min_model) / self.num_bins_rp_model
+        self.bin_size_rt_model = self.rt_max_model / self.num_bins_rt_model
 
-    def _build_mask(self, rp_grid, rt_grid, cuts_config, data_header):
+        self.model_mask = self._build_mask(rp_grid, rt_grid, cuts_config, self.rp_min_model,
+                                           self.bin_size_rp_model, self.bin_size_rt_model)
+
+        return rp_grid, rt_grid, z_grid
+
+    def _build_mask(self, rp_grid, rt_grid, cuts_config, rp_min, bin_size_rp, bin_size_rt):
         """Build the mask for the data by comparing
         the cuts from config with the data limits.
 
@@ -292,7 +366,7 @@ class Data:
             Vector of data rt coordinates
         cuts_config : ConfigParser
             cuts section from config
-        data_header : fits header
+        header : fits header
             Data file header
 
         Returns
@@ -313,30 +387,21 @@ class Data:
         self.mu_min_cut = cuts_config.getfloat('mu-min', -1.)
         self.mu_max_cut = cuts_config.getfloat('mu-max', +1.)
 
-        self.rp_min = data_header['RPMIN']
-        self.rp_max = data_header['RPMAX']
-        self.rt_max = data_header['RTMAX']
-        self.num_bins_rp = data_header['NP']
-        self.num_bins_rt = data_header['NT']
-
-        # Get the data bin size
-        # TODO If RTMIN is ever added to the cf data files this needs modifying
-        self.bin_size_rp = (self.rp_max - self.rp_min) / self.num_bins_rp
-        self.bin_size_rt = self.rt_max / self.num_bins_rt
-
         # Compute bin centers
-        bin_index = np.floor((rp_grid - self.rp_min) / self.bin_size_rp)
-        bin_center_rp = self.rp_min + (bin_index + 0.5) * self.bin_size_rp
-        bin_center_rt = (np.floor(rt_grid / self.bin_size_rt) + 0.5) * self.bin_size_rt
+        bin_index_rp = np.floor((rp_grid - rp_min) / bin_size_rp)
+        bin_center_rp = rp_min + (bin_index_rp + 0.5) * bin_size_rp
+        bin_center_rt = (np.floor(rt_grid / bin_size_rt) + 0.5) * bin_size_rt
 
         bin_center_r = np.sqrt(bin_center_rp**2 + bin_center_rt**2)
         bin_center_mu = bin_center_rp / bin_center_r
 
         # Build the mask by comparing the data bins to the cuts
-        self.mask = (bin_center_rp > rp_min_cut) & (bin_center_rp < rp_max_cut)
-        self.mask &= (bin_center_rt > rt_min_cut) & (bin_center_rt < rt_max_cut)
-        self.mask &= (bin_center_r > self.r_min_cut) & (bin_center_r < self.r_max_cut)
-        self.mask &= (bin_center_mu > self.mu_min_cut) & (bin_center_mu < self.mu_max_cut)
+        mask = (bin_center_rp > rp_min_cut) & (bin_center_rp < rp_max_cut)
+        mask &= (bin_center_rt > rt_min_cut) & (bin_center_rt < rt_max_cut)
+        mask &= (bin_center_r > self.r_min_cut) & (bin_center_r < self.r_max_cut)
+        mask &= (bin_center_mu > self.mu_min_cut) & (bin_center_mu < self.mu_max_cut)
+
+        return mask
 
     def _init_metals(self, metal_config):
         """Read the metal file and initialize all the metal data.

--- a/vega/metals.py
+++ b/vega/metals.py
@@ -85,8 +85,10 @@ class Metals:
 
                 # Get bin sizes
                 if self._data is not None:
-                    self._corr_item.config['metals']['bin_size_rp'] = str(self._data.bin_size_rp)
-                    self._corr_item.config['metals']['bin_size_rt'] = str(self._data.bin_size_rt)
+                    self._corr_item.config['metals']['bin_size_rp'] = \
+                        str(self._corr_item.bin_size_rp_data)
+                    self._corr_item.config['metals']['bin_size_rt'] = \
+                        str(self._corr_item.bin_size_rt_data)
 
                 # Initialize the metal correlation P(k)
                 if self.Pk_metal is None:

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -46,8 +46,8 @@ class VegaPlots:
                 self.cuts[name] = {'r_min': data.r_min_cut,
                                    'r_max': data.r_max_cut}
 
-                if (data.bin_size_rp_data == data.bin_size_rp_model and
-                        data.bin_size_rt_data == data.bin_size_rt_model):
+                if np.allclose([data.bin_size_rp_data, data.bin_size_rt_data],
+                               [data.bin_size_rp_model, data.bin_size_rt_model]):
                     # Compute bin centers
                     bin_index_rp = np.floor((data.corr_item.rp_rt_grid[0] - data.rp_min_model)
                                             / data.bin_size_rp_model)
@@ -213,7 +213,7 @@ class VegaPlots:
         if cov_mat is not None and self.mask is not None:
             covariance = array_or_dict(cov_mat, corr_name)
 
-            if len(self.mask.shape) == len(model_vec):
+            if len(self.mask) == len(model_vec):
                 print('here')
                 masked_model = model_vec[self.mask]
                 if masked_model.shape != self.data[corr_name]:

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -216,7 +216,7 @@ class VegaPlots:
             if len(self.mask) == len(model_vec):
                 print('here')
                 masked_model = model_vec[self.mask]
-                if masked_model.shape != self.data[corr_name]:
+                if len(masked_model) != len(self.data[corr_name]):
                     raise ValueError('Masked model array does not match data array.')
 
         if masked_model is not None:

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -190,7 +190,7 @@ class VegaPlots:
             Whether to use the stored coordinate settings or defaul/input values, by default True
         """
         if use_local_coordinates and self.has_data:
-            wedge_obj = self.initialize_wedge(mu_bin, corr_name, cross_flag, **kwargs)
+            wedge_obj = self.initialize_wedge(mu_bin, corr_name, False, cross_flag, **kwargs)
         else:
             wedge_obj = self.initialize_wedge(mu_bin, cross_flag=cross_flag, **kwargs)
 

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -201,6 +201,7 @@ class VegaPlots:
                 cov_mat = self.cov_mat[corr_name]
 
         model_vec = array_or_dict(model, corr_name)
+        print(model_vec.shape)
 
         if cov_mat is None:
             r, d = wedge_obj(model_vec)

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -38,11 +38,9 @@ class VegaPlots:
                     self.cov_mat[name] = data.cov_mat
 
                 # Initialize data coordinates
-                self.rp_setup_data[name] = (data.rp_min_data,
-                                            data.rp_max_data,
+                self.rp_setup_data[name] = (data.rp_min_data, data.rp_max_data,
                                             data.num_bins_rp_data)
-                self.rt_setup_data[name] = (0., data.rt_max_data,
-                                            data.num_bins_rt_data)
+                self.rt_setup_data[name] = (0., data.rt_max_data, data.num_bins_rt_data)
                 self.r_setup_data[name] = self.rp_setup_data[name]
 
                 self.cuts[name] = {'r_min': data.r_min_cut,
@@ -63,12 +61,12 @@ class VegaPlots:
                     self.mask &= (bin_center_rp < data.rp_max_data)
                     self.mask &= (bin_center_rt < data.rt_max_data)
 
+                    print(self.mask.shape)
+
                 # Initialize model coordinates
-                self.rp_setup_model[name] = (data.rp_min_model,
-                                             data.rp_max_model,
+                self.rp_setup_model[name] = (data.rp_min_model, data.rp_max_model,
                                              data.num_bins_rp_model)
-                self.rt_setup_model[name] = (0., data.rt_max_model,
-                                             data.num_bins_rt_model)
+                self.rt_setup_model[name] = (0., data.rt_max_model, data.num_bins_rt_model)
                 self.r_setup_model[name] = self.rp_setup_model[name]
 
             self.has_data = True
@@ -216,6 +214,7 @@ class VegaPlots:
             covariance = array_or_dict(cov_mat, corr_name)
 
             if len(self.mask.shape) == len(model_vec):
+                print('here')
                 masked_model = model_vec[self.mask]
                 if masked_model.shape != self.data[corr_name]:
                     raise ValueError('Masked model array does not match data array.')

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -200,7 +200,7 @@ class VegaPlots:
 
         model_vec = array_or_dict(model, corr_name)
 
-        if cov_mat is None or wedge_obj.weights.shape[1] != len(model_vec):
+        if cov_mat is None or wedge_obj.weights.shape[1] != cov_mat.shape[0]:
             r, d = wedge_obj(model_vec)
             ax.plot(r, d * r**scaling_power, ls=model_ls, color=model_color, label=label)
         else:

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -30,45 +30,45 @@ class VegaPlots:
         self.mask = None
 
         if vega_data is not None:
-            for name in vega_data.keys():
-                cross_flag = vega_data[name].tracer1['type'] != vega_data[name].tracer2['type']
+            for name, data in vega_data.items():
+                cross_flag = data.tracer1['type'] != data.tracer2['type']
                 self.cross_flag[name] = cross_flag
-                self.data[name] = vega_data[name].data_vec
-                if vega_data[name].has_cov_mat:
-                    self.cov_mat[name] = vega_data[name].cov_mat
+                self.data[name] = data.data_vec
+                if data.has_cov_mat:
+                    self.cov_mat[name] = data.cov_mat
 
                 # Initialize data coordinates
-                self.rp_setup_data[name] = (vega_data[name].rp_min_data,
-                                            vega_data[name].rp_max_data,
-                                            vega_data[name].num_bins_rp_data)
-                self.rt_setup_data[name] = (0., vega_data[name].rt_max_data,
-                                            vega_data[name].num_bins_rt_data)
+                self.rp_setup_data[name] = (data.rp_min_data,
+                                            data.rp_max_data,
+                                            data.num_bins_rp_data)
+                self.rt_setup_data[name] = (0., data.rt_max_data,
+                                            data.num_bins_rt_data)
                 self.r_setup_data[name] = self.rp_setup_data[name]
 
-                self.cuts[name] = {'r_min': vega_data[name].r_min_cut,
-                                   'r_max': vega_data[name].r_max_cut}
+                self.cuts[name] = {'r_min': data.r_min_cut,
+                                   'r_max': data.r_max_cut}
 
-                if (vega_data.bin_size_rp_data == vega_data.bin_size_rp_model and
-                        vega_data.bin_size_rt_data == vega_data.bin_size_rt_model):
+                if (data.bin_size_rp_data == data.bin_size_rp_model and
+                        data.bin_size_rt_data == data.bin_size_rt_model):
                     # Compute bin centers
-                    bin_index_rp = np.floor((vega_data.rp_grid_model - vega_data.rp_min_model)
-                                            / vega_data.bin_size_rp_model)
-                    bin_center_rp = vega_data.rp_min_model
-                    bin_center_rp += (bin_index_rp + 0.5) * vega_data.bin_size_rp_model
-                    bin_index_rt = np.floor(vega_data.rt_grid_model / vega_data.bin_size_rt_model)
-                    bin_center_rt = (bin_index_rt + 0.5) * vega_data.bin_size_rt_model
+                    bin_index_rp = np.floor((data.rp_grid_model - data.rp_min_model)
+                                            / data.bin_size_rp_model)
+                    bin_center_rp = data.rp_min_model
+                    bin_center_rp += (bin_index_rp + 0.5) * data.bin_size_rp_model
+                    bin_index_rt = np.floor(data.rt_grid_model / data.bin_size_rt_model)
+                    bin_center_rt = (bin_index_rt + 0.5) * data.bin_size_rt_model
 
                     # Build the model to data mask
-                    self.mask = (bin_center_rp > vega_data[name].rp_min_data) 
-                    self.mask &= (bin_center_rp < vega_data[name].rp_max_data)
-                    self.mask &= (bin_center_rt < vega_data[name].rt_max_data)
+                    self.mask = (bin_center_rp > data.rp_min_data) 
+                    self.mask &= (bin_center_rp < data.rp_max_data)
+                    self.mask &= (bin_center_rt < data.rt_max_data)
 
                 # Initialize model coordinates
-                self.rp_setup_model[name] = (vega_data[name].rp_min_model,
-                                             vega_data[name].rp_max_model,
-                                             vega_data[name].num_bins_rp_model)
-                self.rt_setup_model[name] = (0., vega_data[name].rt_max_model,
-                                             vega_data[name].num_bins_rt_model)
+                self.rp_setup_model[name] = (data.rp_min_model,
+                                             data.rp_max_model,
+                                             data.num_bins_rp_model)
+                self.rt_setup_model[name] = (0., data.rt_max_model,
+                                             data.num_bins_rt_model)
                 self.r_setup_model[name] = self.rp_setup_model[name]
 
             self.has_data = True

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -61,8 +61,6 @@ class VegaPlots:
                     self.mask &= (bin_center_rp < data.rp_max_data)
                     self.mask &= (bin_center_rt < data.rt_max_data)
 
-                    print(self.mask.shape)
-
                 # Initialize model coordinates
                 self.rp_setup_model[name] = (data.rp_min_model, data.rp_max_model,
                                              data.num_bins_rp_model)
@@ -214,7 +212,6 @@ class VegaPlots:
             covariance = array_or_dict(cov_mat, corr_name)
 
             if len(self.mask) == len(model_vec):
-                print('here')
                 masked_model = model_vec[self.mask]
                 if len(masked_model) != len(self.data[corr_name]):
                     raise ValueError('Masked model array does not match data array.')

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -85,13 +85,13 @@ class VegaPlots:
         """
         if corr_name is not None:
             if is_data:
-                rp = self.rp_setup_model[corr_name]
-                rt = self.rt_setup_model[corr_name]
-                r = self.rp_setup_model[corr_name]
-            else:
                 rp = self.rp_setup_data[corr_name]
                 rt = self.rt_setup_data[corr_name]
                 r = self.rp_setup_data[corr_name]
+            else:
+                rp = self.rp_setup_model[corr_name]
+                rt = self.rt_setup_model[corr_name]
+                r = self.rp_setup_model[corr_name]
             if self.cross_flag[corr_name] and abs_mu:
                 r = (0, rp[1], rp[2]//2)
         else:

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -94,8 +94,6 @@ class VegaPlots:
                 r = self.r_setup_model[corr_name]
             if self.cross_flag[corr_name] and abs_mu:
                 r = (0, rp[1], rp[2]//2)
-
-            print(rp, rt)
         else:
             if rp_setup is not None:
                 rp = rp_setup
@@ -201,9 +199,8 @@ class VegaPlots:
                 cov_mat = self.cov_mat[corr_name]
 
         model_vec = array_or_dict(model, corr_name)
-        print(model_vec.shape)
 
-        if cov_mat is None:
+        if cov_mat is None or wedge_obj.weights.shape[1] != len(model_vec):
             r, d = wedge_obj(model_vec)
             ax.plot(r, d * r**scaling_power, ls=model_ls, color=model_color, label=label)
         else:

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -51,11 +51,11 @@ class VegaPlots:
                 if (data.bin_size_rp_data == data.bin_size_rp_model and
                         data.bin_size_rt_data == data.bin_size_rt_model):
                     # Compute bin centers
-                    bin_index_rp = np.floor((data.rp_grid_model - data.rp_min_model)
+                    bin_index_rp = np.floor((data.corr_item.rp_rt_grid[0] - data.rp_min_model)
                                             / data.bin_size_rp_model)
                     bin_center_rp = data.rp_min_model
                     bin_center_rp += (bin_index_rp + 0.5) * data.bin_size_rp_model
-                    bin_index_rt = np.floor(data.rt_grid_model / data.bin_size_rt_model)
+                    bin_index_rt = np.floor(data.corr_item.rp_rt_grid[1] / data.bin_size_rt_model)
                     bin_center_rt = (bin_index_rt + 0.5) * data.bin_size_rt_model
 
                     # Build the model to data mask

--- a/vega/plots/plot.py
+++ b/vega/plots/plot.py
@@ -87,13 +87,15 @@ class VegaPlots:
             if is_data:
                 rp = self.rp_setup_data[corr_name]
                 rt = self.rt_setup_data[corr_name]
-                r = self.rp_setup_data[corr_name]
+                r = self.r_setup_data[corr_name]
             else:
                 rp = self.rp_setup_model[corr_name]
                 rt = self.rt_setup_model[corr_name]
-                r = self.rp_setup_model[corr_name]
+                r = self.r_setup_model[corr_name]
             if self.cross_flag[corr_name] and abs_mu:
                 r = (0, rp[1], rp[2]//2)
+
+            print(rp, rt)
         else:
             if rp_setup is not None:
                 rp = rp_setup

--- a/vega/vega_interface.py
+++ b/vega/vega_interface.py
@@ -246,10 +246,10 @@ class VegaInterface:
                 return 1e100
 
             if self.monte_carlo:
-                diff = self.data[name].masked_mc_mock - model_cf[self.data[name].mask]
+                diff = self.data[name].masked_mc_mock - model_cf[self.data[name].model_mask]
                 chi2 += diff.T.dot(self.data[name].scaled_inv_masked_cov.dot(diff))
             else:
-                diff = self.data[name].masked_data_vec - model_cf[self.data[name].mask]
+                diff = self.data[name].masked_data_vec - model_cf[self.data[name].model_mask]
                 chi2 += diff.T.dot(self.data[name].inv_masked_cov.dot(diff))
 
         # Add priors
@@ -378,11 +378,11 @@ class VegaInterface:
 
             if self.monte_carlo:
                 diff = self.data[name].masked_mc_mock \
-                    - self.bestfit_model[name][self.data[name].mask]
+                    - self.bestfit_model[name][self.data[name].model_mask]
                 chisq = diff.T.dot(self.data[name].scaled_inv_masked_cov.dot(diff))
             else:
                 diff = self.data[name].masked_data_vec \
-                    - self.bestfit_model[name][self.data[name].mask]
+                    - self.bestfit_model[name][self.data[name].model_mask]
                 chisq = diff.T.dot(self.data[name].inv_masked_cov.dot(diff))
 
             reduced_chisq = chisq / (data_size - num_pars)


### PR DESCRIPTION
When the distortion matrix is computed on a larger coordinate grid than the correlation function (e.g. to 300 Mpc/h), the two cannot be stored in the same fits hdu as picca_export tries to do. This pull request adds the option to directly point vega to the dmat.fits file written by picca_dmat and picca_xdmat. Vega will then use the distortion matrix from that file instead of the one found in the exported correlation file (if any).